### PR TITLE
Fix draft save reporting false failure on non-UIDPLUS servers

### DIFF
--- a/imap_mcp/tools.py
+++ b/imap_mcp/tools.py
@@ -257,7 +257,7 @@ def register_tools(mcp: FastMCP, imap_client: ImapClient) -> None:
             body_html: Optional HTML version of the reply
 
         Returns:
-            Dictionary with status and the UID of the created draft
+            Dictionary with status and the UID of the created draft (None if server lacks UIDPLUS)
         """
         confirmation = await require_confirmation(ctx, "save draft reply", folder, uid)
         if confirmation != ConfirmationResult.CONFIRMED:
@@ -318,8 +318,9 @@ def register_tools(mcp: FastMCP, imap_client: ImapClient) -> None:
         if draft_uid:
             return {"status": "success", "draft_uid": draft_uid}
         return {
-            "status": "error",
-            "message": "Failed to save draft (no UID returned)",
+            "status": "success",
+            "draft_uid": None,
+            "message": "Draft saved (UID not available)",
             "reply_body": reply_body,
         }
 
@@ -844,7 +845,7 @@ def register_tools(mcp: FastMCP, imap_client: ImapClient) -> None:
             Dictionary with the processing result:
               - status: "success", "not_invite", "cancelled", or "error"
               - message: Description of the result
-              - draft_uid: UID of the saved draft (if successful)
+              - draft_uid: UID of the saved draft (None if server lacks UIDPLUS)
               - draft_folder: Folder where the draft was saved (if successful)
               - availability: Whether the time slot was available
         """
@@ -967,7 +968,10 @@ def register_tools(mcp: FastMCP, imap_client: ImapClient) -> None:
                     f"Draft saved successfully with UID {draft_uid} in folder {drafts_folder}"
                 )
             else:
-                result["message"] = "Failed to save draft (no UID returned)"
+                drafts_folder = client._get_drafts_folder()
+                result["status"] = "success"
+                result["message"] = "Draft saved (UID not available)"
+                result["draft_folder"] = drafts_folder
                 result["reply_body"] = reply_content["reply_body"]
 
         except (IMAPClientError, OSError, ValueError) as e:

--- a/tests/test_tools_orchestration.py
+++ b/tests/test_tools_orchestration.py
@@ -359,3 +359,67 @@ class TestMeetingInviteOrchestration:
         mock_generate_reply.assert_called_once()
         mock_create_reply_mime.assert_called_once()
         mock_imap_client.save_draft_mime.assert_called_once_with(mock_mime_message)
+
+    @pytest.mark.asyncio
+    @patch("imap_mcp.smtp_client.create_reply_mime")
+    @patch("imap_mcp.workflows.meeting_reply.generate_meeting_reply_content")
+    @patch("imap_mcp.workflows.calendar_mock.check_mock_availability")
+    @patch("imap_mcp.workflows.invite_parser.identify_meeting_invite_details")
+    @patch("imap_mcp.tools.get_client_from_context")
+    async def test_process_meeting_invite_success_without_uid(
+        self,
+        mock_get_client: Any,
+        mock_identify_invite: Any,
+        mock_check_availability: Any,
+        mock_generate_reply: Any,
+        mock_create_reply_mime: Any,
+        mock_context: Any,
+        mock_imap_client: Any,
+        mock_invite_email: Any,
+        registered_tools: Any,
+    ) -> None:
+        """Test that draft save without UIDPLUS reports success, not error."""
+        mock_get_client.return_value = mock_imap_client
+        mock_imap_client.fetch_email.return_value = mock_invite_email
+
+        mock_identify_invite.return_value = {
+            "is_invite": True,
+            "details": {
+                "subject": "Team Sync",
+                "start_time": datetime(2025, 4, 1, 10, 0, 0),
+                "end_time": datetime(2025, 4, 1, 11, 0, 0),
+                "organizer": "Organizer <organizer@example.com>",
+                "location": "Conference Room",
+            },
+        }
+
+        mock_check_availability.return_value = {
+            "available": True,
+            "reason": "Time slot is available",
+            "alternative_times": [],
+        }
+
+        mock_generate_reply.return_value = {
+            "reply_subject": "Accepted: Team Sync",
+            "reply_body": "I'll attend the meeting...",
+            "reply_type": "accept",
+        }
+
+        mock_mime_message = MagicMock(spec=EmailMessage)
+        mock_create_reply_mime.return_value = mock_mime_message
+
+        mock_imap_client.save_draft_mime.return_value = None
+
+        process_meeting_invite = registered_tools["process_meeting_invite"]
+        result = await process_meeting_invite(
+            folder="INBOX",
+            uid=456,
+            ctx=mock_context,
+            availability_mode="always_available",
+        )
+
+        assert result["status"] == "success"
+        assert result["draft_uid"] is None
+        assert result["draft_folder"] == "Drafts"
+        assert result["availability"] is True
+        mock_imap_client.save_draft_mime.assert_called_once_with(mock_mime_message)

--- a/tests/test_tools_reply.py
+++ b/tests/test_tools_reply.py
@@ -203,6 +203,41 @@ class TestToolsReply:
     @pytest.mark.asyncio
     @patch("imap_mcp.smtp_client.create_reply_mime")
     @patch("imap_mcp.tools.get_client_from_context")
+    async def test_draft_reply_tool_success_without_uid(
+        self,
+        mock_get_client: MagicMock,
+        mock_create_reply: MagicMock,
+        registered_tools: tuple[dict[str, Any], MagicMock],
+        mock_email: Email,
+        mock_context: MagicMock,
+    ) -> None:
+        """Test that draft save without UIDPLUS reports success, not error."""
+        tools_dict, imap_client = registered_tools
+        draft_reply_tool = tools_dict["draft_reply_tool"]
+
+        mock_get_client.return_value = imap_client
+        imap_client.fetch_email.return_value = mock_email
+        imap_client.config.username = "recipient@example.com"
+
+        mime_message = MagicMock()
+        mock_create_reply.return_value = mime_message
+        imap_client.save_draft_mime.return_value = None
+
+        result = await draft_reply_tool(
+            folder="INBOX",
+            uid=1,
+            reply_body="Reply on non-UIDPLUS server",
+            ctx=mock_context,
+        )
+
+        assert result["status"] == "success"
+        assert result["draft_uid"] is None
+        assert "reply_body" in result
+        imap_client.save_draft_mime.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("imap_mcp.smtp_client.create_reply_mime")
+    @patch("imap_mcp.tools.get_client_from_context")
     async def test_draft_reply_uses_config_username_not_to_header(
         self,
         mock_get_client: MagicMock,


### PR DESCRIPTION
Closes #48

## Summary
- `save_draft_mime()` returns `None` when IMAP APPEND succeeds but the server doesn't support UIDPLUS. Both callers (`draft_reply_tool`, `process_meeting_invite`) treated `None` as a hard error, reporting "Failed to save draft" even though the draft was saved.
- Now both callers report `status: "success"` with `draft_uid: None`, preserving response shape for downstream consumers
- `process_meeting_invite` now also populates `draft_folder` in the no-UID path as the remaining stable locator
- Updated docstrings to document that `draft_uid` may be `None`

## Test plan
- Added `test_draft_reply_tool_success_without_uid` in test_tools_reply.py
- Added `test_process_meeting_invite_success_without_uid` in test_tools_orchestration.py
- All 427 tests pass